### PR TITLE
Don't manually configure proxies from environment

### DIFF
--- a/bin/gist
+++ b/bin/gist
@@ -270,18 +270,22 @@ def main(argv=sys.argv[1:], config=None):
             version='gist-v{}'.format(gist.__version__),
             )
 
+    # Setup logging
+    fmt = "%(created).3f %(levelname)s[%(name)s] %(message)s"
+    logging.basicConfig(format=fmt)
+
     # Read in the configuration file
     if config is None:
         config = configparser.ConfigParser()
         config_path = os.path.expanduser('~/.gist')
         config_path = alternative_config(config_path)
         config_path = xdg_data_config(config_path)
-        with open(config_path) as fp:
-            config.readfp(fp)
-
-    # Setup logging
-    fmt = "%(created).3f %(levelname)s[%(name)s] %(message)s"
-    logging.basicConfig(format=fmt)
+        try:
+            with open(config_path) as fp:
+                config.readfp(fp)
+        except Exception as e:
+            message = 'Unable to load configuration file: {0}'.format(e)
+            raise ValueError(message)
 
     try:
         log_level = config.get('gist', 'log-level').upper()

--- a/gist/gist.py
+++ b/gist/gist.py
@@ -138,19 +138,7 @@ class GistAPI(object):
         """
         self.token = token
         self.editor = editor
-        self.proxies = {}
-
-        http_proxy = os.environ.get("http_proxy") \
-            or os.environ.get("HTTP_PROXY")
-
-        if http_proxy is not None:
-            self.proxies["http"] = http_proxy
-
-        https_proxy = os.environ.get("https_proxy") \
-            or os.environ.get("HTTPS_PROXY")
-
-        if https_proxy is not None:
-            self.proxies["https"] = http_proxy
+        self.session = requests.Session()
 
     def send(self, request, stem=None):
         """Prepare and send a request
@@ -166,11 +154,14 @@ class GistAPI(object):
         if stem is not None:
             request.url = request.url + "/" + stem.lstrip("/")
 
-        session = requests.Session()
-        session.proxies = self.proxies
-        prepped = session.prepare_request(request)
+        prepped = self.session.prepare_request(request)
+        settings = self.session.merge_environment_settings(url=prepped.url,
+                                                           proxies={},
+                                                           stream=None,
+                                                           verify=None,
+                                                           cert=None)
 
-        return session.send(prepped)
+        return self.session.send(prepped, **settings)
 
     def list(self):
         """Returns a list of the users gists as GistInfo objects


### PR DESCRIPTION
Requests already does this on its own, and the way it's done here breaks overriding the built-in cert list with REQUESTS_CA_BUNDLE.

https://github.com/kennethreitz/requests/blob/master/docs/user/advanced.rst#proxies