### PR TITLE
fix setup.py 'ascii' codec can't decode byte 0xc3 in position 9191

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
+import io
 import setuptools
 import unittest
-
 
 def discover_test_suite():
     test_loader = unittest.TestLoader()
@@ -15,7 +15,7 @@ setuptools.setup(
         version='0.5.1',
         description='Manage github gists',
         license='MIT',
-        long_description=(open('README.rst').read()),
+        long_description=(io.open('README.rst', 'r', encoding='utf8').read()),
         author='Joshua Downer',
         author_email='joshua.downer@gmail.com',
         url='http://github.com/jdowner/gist',


### PR DESCRIPTION
Observed problem running 'python setup.py install' with Python 3.6.3
Fixed by using explicit 'utf8' encoding reading README.rst

See https://gist.github.com/jq170727/a628bddb9e9591fa10c96c719c17f086
for details to reproduce and demonstrate fix.