### PR TITLE
Add check for empty files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -300,6 +300,7 @@ The configuration file follows the .ini style. The following is an example,
   editor: /usr/bin/vim
   gnupg-homedir: /home/user/.gnupg
   gnupg-fingerprint: 179F9650D9FC1BFE391620B4B13A7829D8DE8623
+  delete-tempfiles: False
 
 The only essential field in the configuration file is the token. This is the
 authentication token from github that grants gist permission to access your
@@ -308,6 +309,11 @@ you wish to use a different editor. 'gnupg-homedir' is the directory where your
 gnupg data are stored, and 'gnupg-fingerprint' is the fingerprint of the key to
 use to encrypt data in your gists. Both gnupg fields are required to support
 encryption/decryption.
+
+The 'delete-tempfiles' option is used when gists are created from an editor.
+The editor writes its contents to a temporary file, which is deleted by
+default. The default behavior can be overridden by using the 'delete-tempfiles'
+flag.
 
 
 Dependencies

--- a/bin/gist
+++ b/bin/gist
@@ -456,11 +456,21 @@ def main(argv=sys.argv[1:], config=None):
                 logger.debug('action: - reading from editor')
                 filename = args.get("<filename>", "file1.txt")
 
-                with tempfile.NamedTemporaryFile('wb+') as fp:
+                # Determine whether the temporary file should be deleted
+                if config.has_option('gist', 'delete-tempfiles'):
+                    delete = config.getboolean('gist', 'delete-tempfiles')
+                else:
+                    delete = True
+
+                with tempfile.NamedTemporaryFile('wb+', delete=delete) as fp:
+                    logger.debug('action: - created {}'.format(fp.name))
                     os.system('{} {}'.format(editor, fp.name))
                     fp.flush()
                     fp.seek(0)
                     files = {filename: fp.read().decode('utf-8')}
+
+                if delete:
+                    logger.debug('action: - removed {}'.format(fp.name))
 
         else:
             logger.debug('action: - reading from stdin')

--- a/bin/gist
+++ b/bin/gist
@@ -485,6 +485,11 @@ def main(argv=sys.argv[1:], config=None):
             filename = args.get("<filename>", "file1.txt")
             files.append(FileInfo(filename, sys.stdin.read()))
 
+        # Ensure that there are no empty files
+        for file in files:
+            if len(file.content) == 0:
+                raise GistError("'{}' is empty".format(file.name))
+
         description = args['<desc>']
         public = args['--public']
 

--- a/bin/gist
+++ b/bin/gist
@@ -122,6 +122,7 @@ Commands:
 """
 
 import codecs
+import collections
 import fcntl
 import locale
 import logging
@@ -160,6 +161,10 @@ class GistError(Exception):
     def __init__(self, msg):
         super(GistError, self).__init__(msg)
         self.msg = msg
+
+
+class FileInfo(collections.namedtuple("FileInfo", "name content")):
+    pass
 
 
 def terminal_width():
@@ -444,14 +449,16 @@ def main(argv=sys.argv[1:], config=None):
                 raise GistError('gnupg-fingerprint missing from config file')
 
         # Retrieve the data to add to the gist
+        files = list()
+
         if sys.stdin.isatty():
             if args['FILES']:
                 logger.debug('action: - reading from files')
-                files = {}
                 for path in args['FILES']:
                     name = os.path.basename(path)
                     with open(path, 'rb') as fp:
-                        files[name] = fp.read().decode('utf-8')
+                        files.append(FileInfo(name, fp.read().decode('utf-8')))
+
             else:
                 logger.debug('action: - reading from editor')
                 filename = args.get("<filename>", "file1.txt")
@@ -467,7 +474,8 @@ def main(argv=sys.argv[1:], config=None):
                     os.system('{} {}'.format(editor, fp.name))
                     fp.flush()
                     fp.seek(0)
-                    files = {filename: fp.read().decode('utf-8')}
+
+                    files.append(FileInfo(filename, fp.read().decode('utf-8')))
 
                 if delete:
                     logger.debug('action: - removed {}'.format(fp.name))
@@ -475,7 +483,7 @@ def main(argv=sys.argv[1:], config=None):
         else:
             logger.debug('action: - reading from stdin')
             filename = args.get("<filename>", "file1.txt")
-            files = {filename: sys.stdin.read()}
+            files.append(FileInfo(filename, sys.stdin.read()))
 
         description = args['<desc>']
         public = args['--public']
@@ -489,12 +497,13 @@ def main(argv=sys.argv[1:], config=None):
 
             gpg = gnupg.GPG(gnupghome=gnupghome, use_agent=True)
             data = {}
-            for k, v in files.items():
-                cypher = gpg.encrypt(v.encode('utf-8'), fingerprint)
+            for file in files:
+                cypher = gpg.encrypt(file.content.encode('utf-8'), fingerprint)
                 content = cypher.data.decode('utf-8')
-                data['{}.asc'.format(k)] = {'content': content}
+
+                data['{}.asc'.format(file.name)] = {'content': content}
         else:
-            data = {k: {'content': v} for k, v in files.items()}
+            data = {file.name: {'content': file.content} for file in files}
 
         print(gapi.create(description, data, public))
         return

--- a/gist/gist.py
+++ b/gist/gist.py
@@ -161,7 +161,12 @@ class GistAPI(object):
                                                            verify=None,
                                                            cert=None)
 
-        return self.session.send(prepped, **settings)
+        response = self.session.send(prepped, **settings)
+
+        if not response.ok:
+            response.raise_for_status()
+
+        return response
 
     def list(self):
         """Returns a list of the users gists as GistInfo objects


### PR DESCRIPTION
This PR introduces a check to ensure that a user is not trying to push an empty file to github; This will cause an error. Also added a check that raises an exception if a 'send' operation to github fails. This provides a more informative error that what is currently displayed.

https://github.com/jdowner/gist/issues/59