### PR TITLE
Add Windows support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ target/
 installed-files.txt
 bin/gistc
 tests/gnupg/*
+
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 # command to install dependencies
 install:

--- a/gist/client.py
+++ b/gist/client.py
@@ -126,15 +126,16 @@ import collections
 import locale
 import logging
 import os
+import platform
 import struct
 import sys
 import tempfile
+
 import docopt
 import gnupg
 import simplejson as json
-import platform
 
-import gist
+from . import gist
 
 if platform.system() != 'Windows':
     # those modules exist everywhere but on Windows
@@ -179,12 +180,14 @@ def terminal_width():
     try:
         if platform.system() == "Windows":
             from ctypes import windll, create_string_buffer
+            # Reference: https://docs.microsoft.com/en-us/windows/console/getstdhandle
             hStdErr = -12
+            get_console_info_fmtstr = "hhhhHhhhhhh"
             herr = windll.kernel32.GetStdHandle(hStdErr)
-            csbi = create_string_buffer(22)
+            csbi = create_string_buffer(struct.calcsize(get_console_info_fmtstr))
             if not windll.kernel32.GetConsoleScreenBufferInfo(herr, csbi):
                 raise OSError("Failed to determine the terminal size")
-            (_, _, _, _, _, left, top, right, bottom, _, _) = struct.unpack("hhhhHhhhhhh", csbi.raw)
+            (_, _, _, _, _, left, top, right, bottom, _, _) = struct.unpack(get_console_info_fmtstr, csbi.raw)
             tty_columns = right - left + 1
             return tty_columns
         else:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-import io
+import io, os
 import setuptools
 import unittest
+import platform
 
 def discover_test_suite():
     test_loader = unittest.TestLoader()
@@ -22,19 +23,18 @@ setuptools.setup(
         keywords='gist github git',
         packages=['gist'],
         package_data={
-          '': ['share/*', '*.rst', 'LICENSE'],
+          '': [os.sep.join(['share','*']), '*.rst', 'LICENSE'],
         },
         data_files=[
-          ('share/gist/', [
+          (os.sep.join(['share','gist']), [
               'README.rst',
               'LICENSE',
-              'share/gist.bash',
-              'share/gist.zsh',
-              'share/gist-fzsl.bash',
-              'share/gist-fzf.bash',
+              os.sep.join(['share', 'gist.bash']),
+              os.sep.join(['share', 'gist.zsh']),
+              os.sep.join(['share', 'gist-fzsl.bash']),
+              os.sep.join(['share', 'gist-fzf.bash']),
               ]),
         ],
-        scripts=['bin/gist'],
         install_requires=[
             'docopt',
             'python-gnupg>=0.4.1',
@@ -52,7 +52,7 @@ setuptools.setup(
             'responses',
             'tox',
         ],
-        platforms=['Unix'],
+        platforms=['Unix', 'Windows'],
         test_suite="setup.discover_test_suite",
         classifiers=[
             'Development Status :: 4 - Beta',
@@ -70,8 +70,17 @@ setuptools.setup(
             'Programming Language :: Python :: 3.4',
             'Programming Language :: Python :: 3.5',
             'Programming Language :: Python :: 3.6',
+            'Programming Language :: Python :: 3.7',
             'Topic :: Software Development',
             'Topic :: Software Development :: Version Control',
             'Topic :: Utilities',
-            ]
+            ],
+
+            # `scripts` provides a non portable approach to creating binaries on the target
+            # `entry_points` is the recommended way to let setuptools do all the hard work.
+            entry_points={
+                'console_scripts': [
+                    'gist = gist.client:main',
+                ],
+            }
         )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
-import io, os
+import io
+import os
+import platform
 import setuptools
 import unittest
-import platform
 
 def discover_test_suite():
     test_loader = unittest.TestLoader()

--- a/tests/test_gist.py
+++ b/tests/test_gist.py
@@ -5,7 +5,6 @@ import base64
 import contextlib
 import errno
 import gnupg
-import imp
 import os
 import shlex
 import subprocess
@@ -30,7 +29,7 @@ import gist
 
 
 # import the CLI script as a module of gist
-setattr(gist, 'cli', imp.load_source('cli', 'bin/gist'))
+import gist.client
 
 
 def kill_gpg_agent(homedir):
@@ -206,7 +205,7 @@ class TestGistCLI(unittest.TestCase):
     def command_response(self, cmd):
         buf = StringIO()
         with redirect_stdout(buf):
-            gist.cli.main(argv=shlex.split(cmd), config=self.config)
+            gist.client.main(argv=shlex.split(cmd), config=self.config)
 
         return buf.getvalue().splitlines()
 
@@ -290,7 +289,7 @@ class TestGistGPG(unittest.TestCase):
         """Return stdout produce by the specified CLI command"""
         buf = StringIO()
         with redirect_stdout(buf):
-            gist.cli.main(argv=shlex.split(cmd), config=self.config)
+            gist.client.main(argv=shlex.split(cmd), config=self.config)
 
         return buf.getvalue().splitlines()
 


### PR DESCRIPTION
Hi,

After using for many years a terrible unmaintained Ruby script to handle my gists, I've started using yours and I'm pretty happy with the features, so thank you for the great tool & lib.
Unfortunately, it doesn't support Windows so I made this PR to provide the same features that exist on Linux to Windows.

The biggest change is probably the fact that I used `setuptools` to handle the automatic creation of an executable file (via [`entry_points`](https://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation)), instead of a hardcoded entry in the `scripts` option. Besides the portability, it also makes packaging a lot easier. Note that it won't change anything to the Linux workflow, but will automatically create the right PE stub on Windows too, and removing everything upon package uninstallation.

Thanks again.