### PR TITLE
gist: Support running command to retrieve token

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,12 @@ The editor field is optional. If the default editor is specified through some
 other mechanism 'gist' will try to infer it. Otherwise, you can use the config
 file to ensure that 'gist' uses the editor you want it to use.
 
+If the token string begins with ``!`` the text following is interpreted as a
+shell command which, when executed, prints the token to stdout. For example::
+
+  [gist]
+  token: !gpg --decrypt github-token.gpg
+
 The configuration file must be in one of the following,
 
 ::


### PR DESCRIPTION
Enable running a shell command defined in the config file to retrieve
the GitHub API token.

Add the function `get_value_from_command` which handles calling the
subprocess when the `string` passed to it begins with `!`, otherwise the
original string is returned.

Updated README.rst to document this new behaviour.

Resolves #65