### PR TITLE
Fix command passed to subprocess call

### DIFF
--- a/gist/client.py
+++ b/gist/client.py
@@ -243,14 +243,13 @@ def get_value_from_command(value):
     """
     command = value.strip()
     if command[0] == '!':
-        process = subprocess.Popen(shlex.quote(command[1:]),
-                                   shell=True,
+        process = subprocess.Popen(shlex.split(command[1:]),
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.PIPE)
         out, err = process.communicate()
         if process.returncode != 0:
             raise GistError(err)
-        return out.strip()
+        return out.decode().strip()
     return value
 
 

--- a/tests/test_gist.py
+++ b/tests/test_gist.py
@@ -265,6 +265,22 @@ class TestGistCLI(unittest.TestCase):
         self.assertIn('file-B.txt:', lines)
         self.assertIn('test-content-\u212C', lines)
 
+    def test_get_value_from_command(self):
+        """
+        Ensure that values which start with ``!`` are treated as commands and
+        return the string printed to stdout by the command, otherwise ensure
+        that the value passed to the function is returned.
+        """
+        self.assertEqual(
+            'magic token',
+            gist.client.get_value_from_command('!echo "\nmagic token"'))
+        self.assertEqual(
+            'magic token',
+            gist.client.get_value_from_command(' !echo "magic token\n"'))
+        self.assertEqual(
+            'magic token',
+            gist.client.get_value_from_command('magic token'))
+
 
 class TestGistGPG(unittest.TestCase):
     gnupghome = os.path.abspath('./tests/gnupg')


### PR DESCRIPTION
Using `shlex.quote()` in conjunction with `shell=True` results in the following error from `sh`:

```
No such file or directory
```

Change to using `shlex.split()` and remove `shell=True` and add the `TestGistCLI.test_get_value_from_command()` unit test.