### PR TITLE
gist: move authentication into headers

### DIFF
--- a/gist/gist.py
+++ b/gist/gist.py
@@ -110,10 +110,8 @@ class authenticate(object):
         """
         try:
             url = "https://api.github.com/gists"
-            params = {"access_token": self.instance.token}
-            request = requests.Request(
-                self.method, url, headers=self.headers, params=params
-            )
+            self.headers["Authorization"] = "token {}".format(self.instance.token)
+            request = requests.Request(self.method, url, headers=self.headers)
             return self.func(self.instance, request, *args, **kwargs)
         finally:
             self.instance = None


### PR DESCRIPTION
The method of passing the authentication token via URL params has been
deprecated. Now, the token should be passed via the headers.

fix #79