### PR TITLE
fix forgotten auth header

### DIFF
--- a/gist/gist.py
+++ b/gist/gist.py
@@ -179,8 +179,9 @@ class GistAPI(object):
                 "Accept-Encoding": "identity, deflate, compress, gzip",
                 "User-Agent": "python-requests/1.2.0",
                 "Accept": "application/vnd.github.v3.base64",
+                "Authorization": "token {}".format(self.token)
             },
-            params={"access_token": self.token, "per_page": 100},
+            params={"per_page": 100},
         )
 
         # Github provides a 'link' header that contains information to


### PR DESCRIPTION
#80 forgot about the authorization of the `GistAPI.list` method.