### PR TITLE
Fix filename bug in `gist create`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ bin/gistc
 tests/gnupg/*
 
 .vscode
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ tests/gnupg/*
 .vscode
 .envrc
 .python-version
+.vimlocal

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ tests/gnupg/*
 .envrc
 .python-version
 .vimlocal
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ tests/gnupg/*
 
 .vscode
 .envrc
+.python-version

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 	$(PYTHON) setup.py build
 
 install: build
-	sudo $(PYTHON) setup.py install \
+	$(PYTHON) setup.py install \
 		--record installed-files.txt \
 		--single-version-externally-managed
 
@@ -14,7 +14,7 @@ uninstall:
 	@if [ -e "installed-files.txt" ]; then \
 		while read path; do \
 			echo $${path}; \
-			sudo rm -rf $${path}; \
+			rm -rf $${path}; \
 		done < "installed-files.txt"; \
 	fi
 

--- a/gist/client.py
+++ b/gist/client.py
@@ -542,7 +542,9 @@ def main(argv=sys.argv[1:], config=None):
 
             else:
                 logger.debug('action: - reading from editor')
-                filename = args.get("<filename>", "file1.txt")
+
+                filename = args["<filename>"]
+                filename = "file1.txt" if filename is None else filename
 
                 # Determine whether the temporary file should be deleted
                 if config.has_option('gist', 'delete-tempfiles'):
@@ -563,7 +565,10 @@ def main(argv=sys.argv[1:], config=None):
 
         else:
             logger.debug('action: - reading from stdin')
-            filename = args.get("<filename>", "file1.txt")
+
+            filename = args["<filename>"]
+            filename = "file1.txt" if filename is None else filename
+
             files.append(FileInfo(filename, sys.stdin.read()))
 
         # Ensure that there are no empty files


### PR DESCRIPTION
The main change here is to fix the filename bug when using `gist create` #90. However, there are a couple of minors infrastructure changes; Namely the removal of `sudo` from the `Makefile` and adding a few more entries to the `.gitignore` file. 