### PR TITLE
client: remove format check

### DIFF
--- a/gist/client.py
+++ b/gist/client.py
@@ -135,7 +135,6 @@ import logging
 import os
 import pathlib
 import platform
-import re
 import shlex
 import struct
 import subprocess
@@ -179,10 +178,6 @@ class GistMissingTokenError(GistError):
 
 
 class GistEmptyTokenError(GistError):
-    pass
-
-
-class GistInvalidTokenError(GistError):
     pass
 
 
@@ -286,13 +281,7 @@ def get_personal_access_token(config):
     except configparser.NoOptionError:
         raise GistMissingTokenError("Missing 'token' field in configuration")
 
-    token = get_value_from_command(value)
-
-    match = re.match(r"[0-9a-fA-F]+$", token)
-    if match is None:
-        raise GistInvalidTokenError("Invalid personal access token")
-
-    return token
+    return get_value_from_command(value)
 
 
 def alternative_editor(default):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -34,13 +34,6 @@ def test_get_personal_access_token_empty(config, token):
         gist.client.get_personal_access_token(config)
 
 
-@pytest.mark.parametrize("token", ["123 123", "foo"])
-def test_get_personal_access_token_invalid(config, token):
-    config.set("gist", "token", token)
-    with pytest.raises(gist.client.GistInvalidTokenError):
-        gist.client.get_personal_access_token(config)
-
-
 @pytest.mark.parametrize("token", ["   123   ", "123abcABC0987"])
 def test_get_personal_access_token_valid(config, token):
     config.set("gist", "token", token)


### PR DESCRIPTION
The format check fails for newer personal access tokens. There doesn't
seem to be a compelling reason to actually enforce the format so I am
removing it.

https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats/